### PR TITLE
Add elrepo-testing and elpreo-extras repositories

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -8,7 +8,7 @@ provisioner:
   require_chef_omnibus: latest
 
 platforms:
-- name: centos-5.8
+- name: centos-5.11
   driver_plugin: digitalocean
   driver_config:
     image_id: 1601
@@ -17,7 +17,7 @@ platforms:
     ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
 
-- name: centos-6.4
+- name: centos-6.6
   driver_plugin: digitalocean
   driver_config:
     image_id: 562354

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,9 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-5.10
-  - name: centos-6.5
+  - name: centos-5.11
+  - name: centos-6.6
+  - name: centos-7.0
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,3 +13,5 @@ suites:
   - name: default
     run_list:
       - recipe[yum-elrepo::default]
+      - recipe[yum-elrepo::extras]
+      - recipe[yum-elrepo::testing]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata

--- a/attributes/extras.rb
+++ b/attributes/extras.rb
@@ -1,0 +1,4 @@
+default['yum']['elrepo-extras']['mirrorlist'] = "http://elrepo.org/mirrors-elrepo-extras.el#{node['platform_version'].to_i}"
+default['yum']['elrepo-extras']['description'] = 'ELRepo.org Extras Yum Repository'
+default['yum']['elrepo-extras']['gpgkey'] = 'http://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo-extras']['enabled'] = true

--- a/attributes/testing.rb
+++ b/attributes/testing.rb
@@ -1,0 +1,5 @@
+
+default['yum']['elrepo-testing']['mirrorlist'] = "http://elrepo.org/mirrors-elrepo-testing.el#{node['platform_version'].to_i}"
+default['yum']['elrepo-testing']['description'] = 'ELRepo.org Testing Yum Repository'
+default['yum']['elrepo-testing']['gpgkey'] = 'http://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo-testing']['enabled'] = true

--- a/recipes/extras.rb
+++ b/recipes/extras.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Sean OMeara (<someara@getchef.com>)
+# Recipe:: yum-elrepo::default
+#
+# Copyright 2013, Chef
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+yum_repository 'elrepo-extras' do
+  description node['yum']['elrepo-extras']['description']
+  baseurl node['yum']['elrepo-extras']['baseurl']
+  mirrorlist node['yum']['elrepo-extras']['mirrorlist']
+  gpgcheck node['yum']['elrepo-extras']['gpgcheck']
+  gpgkey node['yum']['elrepo-extras']['gpgkey']
+  enabled node['yum']['elrepo-extras']['enabled']
+  cost node['yum']['elrepo-extras']['cost']
+  exclude node['yum']['elrepo-extras']['exclude']
+  enablegroups node['yum']['elrepo-extras']['enablegroups']
+  failovermethod node['yum']['elrepo-extras']['failovermethod']
+  http_caching node['yum']['elrepo-extras']['http_caching']
+  include_config node['yum']['elrepo-extras']['include_config']
+  includepkgs node['yum']['elrepo-extras']['includepkgs']
+  keepalive node['yum']['elrepo-extras']['keepalive']
+  max_retries node['yum']['elrepo-extras']['max_retries']
+  metadata_expire node['yum']['elrepo-extras']['metadata_expire']
+  mirror_expire node['yum']['elrepo-extras']['mirror_expire']
+  priority node['yum']['elrepo-extras']['priority']
+  proxy node['yum']['elrepo-extras']['proxy']
+  proxy_username node['yum']['elrepo-extras']['proxy_username']
+  proxy_password node['yum']['elrepo-extras']['proxy_password']
+  repositoryid node['yum']['elrepo-extras']['repositoryid']
+  sslcacert node['yum']['elrepo-extras']['sslcacert']
+  sslclientcert node['yum']['elrepo-extras']['sslclientcert']
+  sslclientkey node['yum']['elrepo-extras']['sslclientkey']
+  sslverify node['yum']['elrepo-extras']['sslverify']
+  timeout node['yum']['elrepo-extras']['timeout']
+  action :create
+end

--- a/recipes/testing.rb
+++ b/recipes/testing.rb
@@ -1,0 +1,49 @@
+#
+# Author:: Sean OMeara (<someara@chef.io>)
+# Author:: Irving Popovetsky (<irving@chef.io>)
+# Recipe:: yum-elrepo::testing
+#
+# Copyright 2015, Chef
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+yum_repository 'elrepo-testing' do
+  description node['yum']['elrepo-testing']['description']
+  baseurl node['yum']['elrepo-testing']['baseurl']
+  mirrorlist node['yum']['elrepo-testing']['mirrorlist']
+  gpgcheck node['yum']['elrepo-testing']['gpgcheck']
+  gpgkey node['yum']['elrepo-testing']['gpgkey']
+  enabled node['yum']['elrepo-testing']['enabled']
+  cost node['yum']['elrepo-testing']['cost']
+  exclude node['yum']['elrepo-testing']['exclude']
+  enablegroups node['yum']['elrepo-testing']['enablegroups']
+  failovermethod node['yum']['elrepo-testing']['failovermethod']
+  http_caching node['yum']['elrepo-testing']['http_caching']
+  include_config node['yum']['elrepo-testing']['include_config']
+  includepkgs node['yum']['elrepo-testing']['includepkgs']
+  keepalive node['yum']['elrepo-testing']['keepalive']
+  max_retries node['yum']['elrepo-testing']['max_retries']
+  metadata_expire node['yum']['elrepo-testing']['metadata_expire']
+  mirror_expire node['yum']['elrepo-testing']['mirror_expire']
+  priority node['yum']['elrepo-testing']['priority']
+  proxy node['yum']['elrepo-testing']['proxy']
+  proxy_username node['yum']['elrepo-testing']['proxy_username']
+  proxy_password node['yum']['elrepo-testing']['proxy_password']
+  repositoryid node['yum']['elrepo-testing']['repositoryid']
+  sslcacert node['yum']['elrepo-testing']['sslcacert']
+  sslclientcert node['yum']['elrepo-testing']['sslclientcert']
+  sslclientkey node['yum']['elrepo-testing']['sslclientkey']
+  sslverify node['yum']['elrepo-testing']['sslverify']
+  timeout node['yum']['elrepo-testing']['timeout']
+  action :create
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,10 +2,30 @@ require 'spec_helper'
 
 describe 'yum-elrepo::default' do
   context 'yum-elrepos::default uses default attributes' do
-    let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+    let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
 
     it 'creates yum_repository[elrepo]' do
       expect(chef_run).to create_yum_repository('elrepo')
+    end
+  end
+end
+
+describe 'yum-elrepo::extras' do
+  context 'yum-elrepos::extras uses default attributes' do
+    let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
+
+    it 'creates yum_repository[elrepo-extras]' do
+      expect(chef_run).to create_yum_repository('elrepo-extras')
+    end
+  end
+end
+
+describe 'yum-elrepo::testing' do
+  context 'yum-elrepos::testing uses default attributes' do
+    let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
+
+    it 'creates yum_repository[elrepo-testing]' do
+      expect(chef_run).to create_yum_repository('elrepo-testing')
     end
   end
 end


### PR DESCRIPTION
I broke these out as separate recipes so there's no behavior change by default.  Please me know if you'd like me to do something different @someara 

Also testing updates:
* Change Berksfile source to resolve rspec deprecation warning
* Change `ChefSpec::Runner` to `ChefSpec::ServerRunner` to resolve rspec deprecation warning
* Add centos-7.0 platform and update centos-5 and centos-6 minor versions.